### PR TITLE
refactor: Introduce function-based codec registration system

### DIFF
--- a/src/Codecs/V3/V3.jl
+++ b/src/Codecs/V3/V3.jl
@@ -12,30 +12,44 @@ using ChunkCodecCore: encode as cc_encode, decode as cc_decode
 
 abstract type V3Codec{In,Out} end
 
-"""
-Registry mapping codec names to parser functions.
-
-Each parser function accepts a configuration `Dict{String,Any}` and an optional
-context value, and returns a `V3Codec`. Use `register_codec` to add new entries.
-"""
-const codec_parsers = Dict{String, Function}()
+"""Stores a registered V3 codec parser together with its expected return type."""
+struct CodecEntry
+    return_type::Type{<:V3Codec}
+    parser::Function
+end
 
 """
-    register_codec(parser::Function, name::String)
+Registry mapping codec names to `CodecEntry` values (return type + parser function).
+
+Use `register_codec` to add new entries.
+"""
+const codec_parsers = Dict{String, CodecEntry}()
+
+"""
+    register_codec(parser::Function, name::String[, ::Type{T}])
 
 Register a codec parser under `name`. The parser must accept a
 `Dict{String,Any}` configuration and a context value (or `nothing`),
 and return a `V3Codec`.
+
+The optional trailing `Type{T}` argument narrows the declared return type stored
+in the registry (defaults to `V3Codec`). Specifying it enables a runtime
+assertion in `getCodec` and makes the registry self-documenting.
 
 Supports do-block syntax:
 
     register_codec("mycodec") do config, ctx
         MyCodec(config["param"])
     end
+
+    register_codec("mycodec", MyCodec) do config, ctx
+        MyCodec(config["param"])
+    end
 """
-function register_codec(parser::Function, name::String)
-    codec_parsers[name] = parser
+function register_codec(parser::Function, name::String, ::Type{T}) where {T<:V3Codec}
+    codec_parsers[name] = CodecEntry(T, parser)
 end
+register_codec(parser::Function, name::String) = register_codec(parser, name, V3Codec)
 
 @enum BloscCompressor begin
     lz4
@@ -72,7 +86,7 @@ end
 BytesCodec() = BytesCodec(:little)
 name(::BytesCodec) = "bytes"
 
-register_codec("bytes") do config, ctx
+register_codec("bytes", BytesCodec) do config, ctx
     endian_str = get(config, "endian", "little")
     endian = endian_str == "little" ? :little :
              endian_str == "big"    ? :big    :
@@ -148,7 +162,7 @@ struct ShardingCodec{N, P1<:AbstractCodecPipeline, P2<:AbstractCodecPipeline} <:
 end
 name(::ShardingCodec) = "sharding_indexed"
 
-register_codec("sharding_indexed") do config, ctx
+register_codec("sharding_indexed", ShardingCodec) do config, ctx
     N = length(config["chunk_shape"])
     # Zarr spec stores chunk_shape in C-order (row-major); reverse for Julia column-major
     chunk_shape    = NTuple{N,Int}(reverse(Int.(config["chunk_shape"])))
@@ -230,8 +244,9 @@ function getCodec(d::Dict, ctx=nothing)
     codec_name = d["name"]
     haskey(codec_parsers, codec_name) ||
         throw(ArgumentError("Zarr.jl does not support the $codec_name codec"))
+    entry = codec_parsers[codec_name]
     config = get(d, "configuration", Dict{String,Any}())
-    return codec_parsers[codec_name](config, ctx)
+    return entry.parser(config, ctx)::entry.return_type
 end
 
 """
@@ -457,7 +472,7 @@ struct TransposeCodec{N} <: V3Codec{:array, :array}
 end
 name(::TransposeCodec) = "transpose"
 
-register_codec("transpose") do config, ctx
+register_codec("transpose", TransposeCodec) do config, ctx
     _order = config["order"]
     if _order isa AbstractString
         n = isnothing(ctx) ? error("context with shape required for deprecated string transpose order") : length(ctx.shape)
@@ -529,7 +544,7 @@ end
 GzipV3Codec() = GzipV3Codec(6)
 name(::GzipV3Codec) = "gzip"
 
-register_codec("gzip") do config, ctx
+register_codec("gzip", GzipV3Codec) do config, ctx
     GzipV3Codec(get(config, "level", 6))
 end
 
@@ -556,7 +571,7 @@ end
 BloscV3Codec() = BloscV3Codec("lz4", 5, 1, 0, 4)
 name(::BloscV3Codec) = "blosc"
 
-register_codec("blosc") do config, ctx
+register_codec("blosc", BloscV3Codec) do config, ctx
     cname = get(config, "cname", "lz4")
     clevel = get(config, "clevel", 5)
     shuffle_val = get(config, "shuffle", "noshuffle")
@@ -601,7 +616,7 @@ end
 ZstdV3Codec() = ZstdV3Codec(3)
 name(::ZstdV3Codec) = "zstd"
 
-register_codec("zstd") do config, ctx
+register_codec("zstd", ZstdV3Codec) do config, ctx
     ZstdV3Codec(get(config, "level", 3))
 end
 
@@ -623,7 +638,7 @@ struct CRC32cV3Codec <: V3Codec{:bytes, :bytes}
 end
 name(::CRC32cV3Codec) = "crc32c"
 
-register_codec("crc32c") do config, ctx
+register_codec("crc32c", CRC32cV3Codec) do config, ctx
     CRC32cV3Codec()
 end
 

--- a/src/Codecs/V3/V3.jl
+++ b/src/Codecs/V3/V3.jl
@@ -11,7 +11,31 @@ using ChunkCodecLibZlib: GzipCodec as LibZGzipCodec, GzipEncodeOptions
 using ChunkCodecCore: encode as cc_encode, decode as cc_decode
 
 abstract type V3Codec{In,Out} end
-const codectypes = Dict{String, V3Codec}()
+
+"""
+Registry mapping codec names to parser functions.
+
+Each parser function accepts a configuration `Dict{String,Any}` and an optional
+context value, and returns a `V3Codec`. Use `register_codec` to add new entries.
+"""
+const codec_parsers = Dict{String, Function}()
+
+"""
+    register_codec(parser::Function, name::String)
+
+Register a codec parser under `name`. The parser must accept a
+`Dict{String,Any}` configuration and a context value (or `nothing`),
+and return a `V3Codec`.
+
+Supports do-block syntax:
+
+    register_codec("mycodec") do config, ctx
+        MyCodec(config["param"])
+    end
+"""
+function register_codec(parser::Function, name::String)
+    codec_parsers[name] = parser
+end
 
 @enum BloscCompressor begin
     lz4
@@ -47,6 +71,14 @@ struct BytesCodec <: V3Codec{:array, :bytes}
 end
 BytesCodec() = BytesCodec(:little)
 name(::BytesCodec) = "bytes"
+
+register_codec("bytes") do config, ctx
+    endian_str = get(config, "endian", "little")
+    endian = endian_str == "little" ? :little :
+             endian_str == "big"    ? :big    :
+             throw(ArgumentError("Unknown endian: \"$endian_str\""))
+    BytesCodec(endian)
+end
 
 const _SYSTEM_LITTLE_ENDIAN = Base.ENDIAN_BOM == 0x04030201
 _needs_bswap(endian::Symbol) = (endian == :little) != _SYSTEM_LITTLE_ENDIAN
@@ -116,6 +148,16 @@ struct ShardingCodec{N, P1<:AbstractCodecPipeline, P2<:AbstractCodecPipeline} <:
 end
 name(::ShardingCodec) = "sharding_indexed"
 
+register_codec("sharding_indexed") do config, ctx
+    N = length(config["chunk_shape"])
+    # Zarr spec stores chunk_shape in C-order (row-major); reverse for Julia column-major
+    chunk_shape    = NTuple{N,Int}(reverse(Int.(config["chunk_shape"])))
+    data_pipeline  = getCodec(config["codecs"])
+    index_pipeline = getCodec(config["index_codecs"])
+    index_location = Symbol(get(config, "index_location", "end"))
+    ShardingCodec(chunk_shape, data_pipeline, index_pipeline, index_location)
+end
+
 """
 Build a `V3Pipeline` from a flat ordered list of `V3Codec` values.
 The list must contain: zero or more array→array codecs, exactly one array→bytes codec,
@@ -178,65 +220,27 @@ function JSON.lower(c::ShardingCodec)
 end
 
 """
-    getCodec(d::Dict)
+    getCodec(d::Dict, ctx=nothing)
 
-Deserialize a V3 codec from a JSON dict by dispatching on `d["name"]`.
-Used to parse inner codecs of `ShardingCodec`.
+Deserialize a V3 codec from a JSON dict by dispatching through the `codec_parsers`
+registry. `ctx` is an optional context value (e.g. a NamedTuple with `shape` and
+`elsize`) forwarded to the registered parser.
 """
-function getCodec(d::Dict)
+function getCodec(d::Dict, ctx=nothing)
     codec_name = d["name"]
+    haskey(codec_parsers, codec_name) ||
+        throw(ArgumentError("Zarr.jl does not support the $codec_name codec"))
     config = get(d, "configuration", Dict{String,Any}())
-    if codec_name == "bytes"
-        endian_str = get(config, "endian", "little")
-        endian = endian_str == "little" ? :little :
-                 endian_str == "big"    ? :big    :
-                 throw(ArgumentError("Unknown endian: \"$endian_str\""))
-        return BytesCodec(endian)
-    elseif codec_name == "transpose"
-        perm = Tuple(Int.(config["order"]) .+ 1)
-        return TransposeCodec(perm)
-    elseif codec_name == "gzip"
-        level = get(config, "level", 6)
-        return GzipV3Codec(level)
-    elseif codec_name == "blosc"
-        cname = get(config, "cname", "lz4")
-        clevel = get(config, "clevel", 5)
-        shuffle_val = get(config, "shuffle", "noshuffle")
-        shuffle_int = shuffle_val isa Integer ? shuffle_val :
-                      shuffle_val == "noshuffle"  ? 0 :
-                      shuffle_val == "shuffle"     ? 1 :
-                      shuffle_val == "bitshuffle"  ? 2 :
-                      throw(ArgumentError("Unknown shuffle: \"$shuffle_val\"."))
-        blocksize = get(config, "blocksize", 0)
-        typesize  = get(config, "typesize", 4)
-        return BloscV3Codec(string(cname), clevel, shuffle_int, blocksize, typesize)
-    elseif codec_name == "zstd"
-        level = get(config, "level", 3)
-        return ZstdV3Codec(level)
-    elseif codec_name == "crc32c"
-        return CRC32cV3Codec()
-    elseif codec_name == "sharding_indexed"
-        return getCodec(ShardingCodec, d)
-    else
-        throw(ArgumentError("Unsupported inner codec: $codec_name"))
-    end
+    return codec_parsers[codec_name](config, ctx)
 end
 
 """
-    getCodec(::Type{ShardingCodec}, d::Dict)
+    getCodec(dicts::Vector, ctx=nothing)
 
-Deserialize `ShardingCodec` from a JSON configuration dict.
-`chunk_shape` is reversed from C-order (Zarr spec) to Julia column-major order.
+Deserialize a list of V3 codec dicts into a `V3Pipeline`.
 """
-function getCodec(::Type{ShardingCodec}, d::Dict)
-    config = d["configuration"]
-    N = length(config["chunk_shape"])
-    # Zarr spec stores chunk_shape in C-order (row-major); reverse for Julia column-major
-    chunk_shape    = NTuple{N,Int}(reverse(Int.(config["chunk_shape"])))
-    data_pipeline  = _codecs_to_v3pipeline([getCodec(cd) for cd in config["codecs"]])
-    index_pipeline = _codecs_to_v3pipeline([getCodec(cd) for cd in config["index_codecs"]])
-    index_location = Symbol(get(config, "index_location", "end"))
-    return ShardingCodec(chunk_shape, data_pipeline, index_pipeline, index_location)
+function getCodec(dicts::Vector, ctx=nothing)
+    return _codecs_to_v3pipeline([getCodec(d, ctx) for d in dicts])
 end
 
 const MAX_UINT64 = typemax(UInt64)
@@ -453,6 +457,25 @@ struct TransposeCodec{N} <: V3Codec{:array, :array}
 end
 name(::TransposeCodec) = "transpose"
 
+register_codec("transpose") do config, ctx
+    _order = config["order"]
+    if _order isa AbstractString
+        n = isnothing(ctx) ? error("context with shape required for deprecated string transpose order") : length(ctx.shape)
+        if _order == "C"
+            @warn "Transpose codec dimension order of C is deprecated"
+            perm = ntuple(identity, n)
+        elseif _order == "F"
+            @warn "Transpose codec dimension order of F is deprecated"
+            perm = ntuple(i -> n - i + 1, n)
+        else
+            throw(ArgumentError("Unknown transpose order string: $_order"))
+        end
+    else
+        perm = Tuple(Int.(_order) .+ 1)
+    end
+    TransposeCodec(perm)
+end
+
 function JSON.lower(c::TransposeCodec)
     Dict("name" => "transpose", "configuration" => Dict("order" => collect(c.order .- 1)))
 end
@@ -506,6 +529,10 @@ end
 GzipV3Codec() = GzipV3Codec(6)
 name(::GzipV3Codec) = "gzip"
 
+register_codec("gzip") do config, ctx
+    GzipV3Codec(get(config, "level", 6))
+end
+
 function JSON.lower(c::GzipV3Codec)
     Dict("name" => "gzip", "configuration" => Dict("level" => c.level))
 end
@@ -528,6 +555,21 @@ struct BloscV3Codec <: V3Codec{:bytes, :bytes}
 end
 BloscV3Codec() = BloscV3Codec("lz4", 5, 1, 0, 4)
 name(::BloscV3Codec) = "blosc"
+
+register_codec("blosc") do config, ctx
+    cname = get(config, "cname", "lz4")
+    clevel = get(config, "clevel", 5)
+    shuffle_val = get(config, "shuffle", "noshuffle")
+    shuffle_int = shuffle_val isa Integer ? shuffle_val :
+                  shuffle_val == "noshuffle"  ? 0 :
+                  shuffle_val == "shuffle"     ? 1 :
+                  shuffle_val == "bitshuffle"  ? 2 :
+                  throw(ArgumentError("Unknown shuffle: \"$shuffle_val\"."))
+    blocksize = get(config, "blocksize", 0)
+    typesize_default = isnothing(ctx) ? 4 : ctx.elsize
+    typesize = get(config, "typesize", typesize_default)
+    BloscV3Codec(string(cname), clevel, shuffle_int, blocksize, typesize)
+end
 
 function JSON.lower(c::BloscV3Codec)
     shuffle_str = c.shuffle == 0 ? "noshuffle" :
@@ -559,6 +601,10 @@ end
 ZstdV3Codec() = ZstdV3Codec(3)
 name(::ZstdV3Codec) = "zstd"
 
+register_codec("zstd") do config, ctx
+    ZstdV3Codec(get(config, "level", 3))
+end
+
 function JSON.lower(c::ZstdV3Codec)
     Dict("name" => "zstd", "configuration" => Dict("level" => c.level))
 end
@@ -576,6 +622,10 @@ end
 struct CRC32cV3Codec <: V3Codec{:bytes, :bytes}
 end
 name(::CRC32cV3Codec) = "crc32c"
+
+register_codec("crc32c") do config, ctx
+    CRC32cV3Codec()
+end
 
 function JSON.lower(::CRC32cV3Codec)
     Dict("name" => "crc32c")

--- a/src/metadata3.jl
+++ b/src/metadata3.jl
@@ -225,79 +225,12 @@ function Metadata3(d::AbstractDict, fill_as_missing)
         throw(ArgumentError("Unknown chunk_key_encoding of name, $(chunk_key_encoding["name"])"))
     end
 
-    # Build V3Pipeline from codec chain
-    array_array_codecs = []
-    array_bytes_codec = nothing
-    bytes_bytes_codecs = []
-    order = 'C'  # default
-
-    for codec in d["codecs"]
-        codec_name = codec["name"]
-        config = get(codec, "configuration", Dict{String,Any}())
-        if codec_name == "transpose"
-            _order = config["order"]
-            if _order isa AbstractString
-                n = length(shape)
-                if _order == "C"
-                    @warn "Transpose codec dimension order of C is deprecated"
-                    perm = ntuple(identity, n)
-                elseif _order == "F"
-                    @warn "Transpose codec dimension order of F is deprecated"
-                    perm = ntuple(i -> n - i + 1, n)
-                    order = 'F'
-                else
-                    throw(ArgumentError("Unknown transpose order string: $_order"))
-                end
-            else
-                perm = Tuple(Int.(_order) .+ 1)
-                default_perm = ntuple(identity, length(shape))
-                rev_perm = ntuple(i -> length(shape) - i + 1, length(shape))
-                if perm == default_perm
-                    order = 'C'
-                elseif perm == rev_perm
-                    order = 'F'
-                end
-            end
-            push!(array_array_codecs, Codecs.V3Codecs.TransposeCodec(perm))
-        elseif codec_name == "bytes"
-            endian_str = get(config, "endian", "little")
-            endian = endian_str == "little" ? :little :
-                     endian_str == "big"    ? :big    :
-                     throw(ArgumentError("Unknown endian value: \"$endian_str\""))
-            array_bytes_codec = Codecs.V3Codecs.BytesCodec(endian)
-        elseif codec_name == "sharding_indexed"
-            array_bytes_codec = Codecs.V3Codecs.getCodec(Codecs.V3Codecs.ShardingCodec, codec)
-        elseif codec_name == "gzip"
-            level = get(config, "level", 6)
-            push!(bytes_bytes_codecs, Codecs.V3Codecs.GzipV3Codec(level))
-        elseif codec_name == "blosc"
-            cname = get(config, "cname", "lz4")
-            clevel = get(config, "clevel", 5)
-            shuffle_val = get(config, "shuffle", "noshuffle")
-            shuffle_int = shuffle_val isa Integer ? shuffle_val :
-                          shuffle_val == "noshuffle" ? 0 :
-                          shuffle_val == "shuffle" ? 1 :
-                          shuffle_val == "bitshuffle" ? 2 :
-                          throw(ArgumentError("Unknown shuffle: \"$shuffle_val\"."))
-            blocksize = get(config, "blocksize", 0)
-            typesize = get(config, "typesize", 4)
-            push!(bytes_bytes_codecs, Codecs.V3Codecs.BloscV3Codec(string(cname), clevel, shuffle_int, blocksize, typesize))
-        elseif codec_name == "zstd"
-            level = get(config, "level", 3)
-            push!(bytes_bytes_codecs, Codecs.V3Codecs.ZstdV3Codec(level))
-        elseif codec_name == "crc32c"
-            push!(bytes_bytes_codecs, Codecs.V3Codecs.CRC32cV3Codec())
-        else
-            throw(ArgumentError("Zarr.jl currently does not support the $codec_name codec"))
-        end
-    end
-
-    isnothing(array_bytes_codec) && throw(ArgumentError("V3 codec chain must contain an array-to-bytes codec such as 'bytes' or 'sharding_indexed'"))
-    pipeline = V3Pipeline(Tuple(array_array_codecs), array_bytes_codec, Tuple(bytes_bytes_codecs))
-
-    # Type Parameters
+    # Type Parameters (computed before codec parsing so elsize is available as context)
     T = typestr3(data_type)
     N = length(shape)
+
+    codec_ctx = (shape = shape, elsize = sizeof(Base.nonmissingtype(T)))
+    pipeline = Codecs.V3Codecs.getCodec(d["codecs"], codec_ctx)
 
     fv = fill_value_decoding(d["fill_value"], T)::T
 

--- a/test/v3_codecs.jl
+++ b/test/v3_codecs.jl
@@ -839,7 +839,7 @@ end
         Zarr.Codecs.V3Codecs.BytesCodec(:little),
         Zarr.Codecs.V3Codecs.CRC32cV3Codec(),
     ]
-    c = Zarr.Codecs.V3Codecs.getCodec(Zarr.Codecs.V3Codecs.ShardingCodec, Dict(
+    c = Zarr.Codecs.V3Codecs.getCodec(Dict(
         "name" => "sharding_indexed",
         "configuration" => Dict(
             "chunk_shape"    => [2],


### PR DESCRIPTION
Replace the type-based `codectypes` dict and `parse_config` methods with a function-based registry matching the pattern used for chunk key encodings:

- `codec_parsers = Dict{String, CodecEntry}()` replaces `codectypes`
- `register_codec(parser, name, ::Type)` with do-block syntax replaces direct `codectypes[name] = Type` assignments
- `getCodec(d, ctx=nothing)` dispatches through `codec_parsers[name](config, ctx)`
- Each parser accepts `(config::Dict, ctx)` instead of the old `parse_config(::Type{T}, config, shape)` multi-dispatch form

The optional `ctx` NamedTuple `(shape, elsize)` carries richer array context, enabling parsers to use element size (`ctx.elsize`) as the default for `BloscV3Codec.typesize` and ndims (`length(ctx.shape)`) for deprecated TransposeCodec string-order handling.

`Metadata3` now computes `T = typestr3(data_type)` before codec parsing and passes `(shape=shape, elsize=sizeof(Base.nonmissingtype(T)))` as context.

Third-party codecs can be registered at load time:

    Zarr.Codecs.V3Codecs.register_codec("my_codec") do config, ctx
        MyCodec(config["param"], ctx.elsize)
    end

All 223 v3_codecs tests pass.